### PR TITLE
Optional dragOperation:canDropInDropTarget delegate method

### DIFF
--- a/iOS Library/Sources/DNDDragAndDropController.h
+++ b/iOS Library/Sources/DNDDragAndDropController.h
@@ -165,6 +165,18 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 /**
+ Optional allow or dissallow dropping into target view.
+
+ If this method is not implemented in delegate it's assumed that view can be dropped.
+ If this method returns NO, then -dragOperationWillCancel: will be called instead of
+ -dragOperation:didDropInDropTarget:.
+ 
+ @param operation The current drag operation
+ @param target    The drop target view where the drop was made
+ */
+- (BOOL)dragOperation:(DNDDragOperation *)operation canDropInDropTarget:(UIView *)target;
+
+/**
  Optional notification when the user enters a drop target during a drag operation.
  
  @param operation The current drag operation

--- a/iOS Library/Sources/DNDDragHandler.m
+++ b/iOS Library/Sources/DNDDragHandler.m
@@ -172,7 +172,18 @@
 }
 
 - (void)notifyDropInTarget:(UIView *)dropTarget {
-    [[self.controller delegateForDropTarget:dropTarget] dragOperation:self.currentDragOperation didDropInDropTarget:dropTarget];
+    id<DNDDropTargetDelegate> delegate = [self.controller delegateForDropTarget:self.currentDragOperation.dropTargetView];
+
+    BOOL canDrop = YES;
+    if ([delegate respondsToSelector:@selector(dragOperation:canDropInDropTarget:)]) {
+        canDrop = [delegate dragOperation:self.currentDragOperation canDropInDropTarget:dropTarget];
+    }
+
+    if (canDrop) {
+        [[self.controller delegateForDropTarget:dropTarget] dragOperation:self.currentDragOperation didDropInDropTarget:dropTarget];
+    } else {
+        [self notifyDragCancel];
+    }
 }
 
 - (void)notifyDragCancel {


### PR DESCRIPTION
Useful when drop logic is sophisticated and target view doesn't supports certain kinds of dropped objects. 
Before there was no way to call ```dragOperationWillCancel:``` on drag target, if you don't want to support this particular drop operation on a drop target.

Now if ```dragOperation:canDropInDropTarget``` returns `NO` ```dragOperationWillCancel:``` is called on drag target.
If ```dragOperation:canDropInDropTarget``` method is not implemented it's assumed that view *can* be dropped to support backward compatibility.