### PR TITLE
dragPaneView returns self.window to allow drag and drop between view in modally presented view controller and view in presenting view controller

### DIFF
--- a/iOS Library/Sources/DNDDragAndDropController.m
+++ b/iOS Library/Sources/DNDDragAndDropController.m
@@ -40,11 +40,7 @@
 #pragma mark - Getting Views
 
 - (UIView *)dragPaneView {
-    UIViewController *frontViewController = self.window.rootViewController;
-    while (frontViewController.presentedViewController != nil) {
-        frontViewController = frontViewController.presentedViewController;
-    }
-    return frontViewController.view;
+    return self.window;
 }
 
 - (UIView *)dropTargetAtLocation:(CGPoint)location {


### PR DESCRIPTION
I'm not sure about your intention to return view from topmost view controller in ```dragPaneView``` method.
It blocks possibility to drop things from modally presented view controller to a view of a presenting view controller. Can't you just use ```self.window``` here?